### PR TITLE
concatenate line # to _ui_scope_guard variable names to prevent shadowing when nesting calls to macros

### DIFF
--- a/imgui_sugar.hpp
+++ b/imgui_sugar.hpp
@@ -103,16 +103,16 @@ namespace ImGuiSugar
 // +----------------------+-------------------+-----------------+---------------------+
 
 #define IMGUI_SUGAR_SCOPED_BOOL(BEGIN, END, ALWAYS, ...) \
-    if (const ImGuiSugar::BooleanGuard<ALWAYS> _ui_scope_guard = {BEGIN(__VA_ARGS__), &END})
+    if (const ImGuiSugar::BooleanGuard<ALWAYS> IMGUI_SUGAR_CONCAT1( _ui_scope_guard, __LINE__ ) = {BEGIN(__VA_ARGS__), &END})
 
 #define IMGUI_SUGAR_SCOPED_BOOL_0(BEGIN, END, ALWAYS) \
-    if (const ImGuiSugar::BooleanGuard<ALWAYS> _ui_scope_guard = {BEGIN(), &END})
+    if (const ImGuiSugar::BooleanGuard<ALWAYS> IMGUI_SUGAR_CONCAT1( _ui_scope_guard, __LINE__ ) = {BEGIN(), &END})
 
 #define IMGUI_SUGAR_SCOPED_VOID_N(BEGIN, END, ...) \
-    if (const ImGuiSugar::BooleanGuard<true> _ui_scope_guard = {IMGUI_SUGAR_ES(BEGIN, __VA_ARGS__), &END})
+    if (const ImGuiSugar::BooleanGuard<true> IMGUI_SUGAR_CONCAT1( _ui_scope_guard, __LINE__ ) = {IMGUI_SUGAR_ES(BEGIN, __VA_ARGS__), &END})
 
 #define IMGUI_SUGAR_SCOPED_VOID_0(BEGIN, END) \
-    if (const ImGuiSugar::BooleanGuard<true> _ui_scope_guard = {IMGUI_SUGAR_ES_0(BEGIN), &END})
+    if (const ImGuiSugar::BooleanGuard<true> IMGUI_SUGAR_CONCAT1( _ui_scope_guard, __LINE__ ) = {IMGUI_SUGAR_ES_0(BEGIN), &END})
 
 #define IMGUI_SUGAR_PARENT_SCOPED_VOID_N(BEGIN, END, ...) \
     const ImGuiSugar::BooleanGuard<true> IMGUI_SUGAR_CONCAT1(_ui_scope_, __LINE__) = {IMGUI_SUGAR_ES(BEGIN, __VA_ARGS__), &END}


### PR DESCRIPTION
Dear  Frank David Martínez M,

Greetings & Salutations.
First, please feel free to ignore this, I'm neither a professional nor really sure what I'm doing.  This is my first real pull request.
Second, thank-you for imgui_sugar, it was exactly what I was looking for.  It is a brilliant use of macros to accomplish what would otherwise be a very tedious job of creating RAII wrappers for ImGui.

**The Issue:**
I noticed when nesting imgui_sugar `with_*` macro calls my compiler generated variable shadowing warnings/errors.  
To remedy this I simply concatenated the line number to the variable name (`_ui_scope_guard`) for each of the `IMGUI_SUGAR_SCOPED_*` macros.
This is already done in the `IMGUI_SUGAR_PARENT_SCOPED_VOID_N` macro.

I hope this helps.  I apologize in advance if I've done something wrong, inappropriate or just plain stupid.
I hope you have a great day!

Sincerely,
William Weston.

