### PR TITLE
Add with_Disabled macro for scoped disabled state management

### DIFF
--- a/imgui_sugar.hpp
+++ b/imgui_sugar.hpp
@@ -160,6 +160,7 @@ namespace ImGuiSugar
 #define with_ID(...)                 IMGUI_SUGAR_SCOPED_VOID_N(ImGui::PushID,                 ImGui::PopID,                 __VA_ARGS__)
 #define with_ClipRect(...)           IMGUI_SUGAR_SCOPED_VOID_N(ImGui::PushClipRect,           ImGui::PopClipRect,           __VA_ARGS__)
 #define with_TextureID(...)          IMGUI_SUGAR_SCOPED_VOID_N(ImGui::PushTextureID,          ImGui::PopTextureID,          __VA_ARGS__)
+#define with_Disabled(...)           IMGUI_SUGAR_SCOPED_VOID_N(ImGui::BeginDisabled,          ImGui::EndDisabled,           __VA_ARGS__)
 
 // Non self scoped guards (managed by parent scope)
 


### PR DESCRIPTION
I've added a `with_Disabled` macro that scopes the `ImGui::BeginDisabled` and `ImGui::EndDisabled` functions.
I've used in a personal project and it seems to work correctly.
I'm a non-professional programmer so if anything is wrong, please don't hold back.  Failure is how I learn.

Sincerely, 

William.